### PR TITLE
Allowed for precompiled partials

### DIFF
--- a/lib/handlebars-layouts.js
+++ b/lib/handlebars-layouts.js
@@ -21,7 +21,11 @@ module.exports = function (handlebars) {
             options.fn(context);
 
             // Render final layout partial with revised blocks
-            return handlebars.compile(template)(context);
+            if (typeof template === 'function') {
+                return template(context);
+            } else {
+                return handlebars.compile(template)(context);
+            }
         },
 
         append: function (block, options) {


### PR DESCRIPTION
The extend helper was assuming the parent partial was not already compiled. I added a check to see if the parent partial is a function, and if so, just invoke it directly rather than trying to recompile.
